### PR TITLE
Implement message backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You can find the original extension in [Chrome Web Store](https://chrome.google.
 - Block "read" receipts sending, and decide when to send them later (works for statuses as well)
 - Block "typing"/"seen" updates (Will prevent you from seeing others')
 - Always restore deleted messages of all kinds
+- Automatically back up all incoming messages
 - See whether every message was sent from a phone or a computer
 - Download statuses
 ## Installing from GitHub directly

--- a/core/interception.js
+++ b/core/interception.js
@@ -392,6 +392,7 @@ function initialize()
     if (WALogs)
         hookLogs();
     initializeDeletedMessagesDB();
+    initializeBackupMessagesDB();
 }
 
 function hookLogs()
@@ -496,6 +497,28 @@ function initializeDeletedMessagesDB()
     }
 }
 
+function initializeBackupMessagesDB()
+{
+    var backupDBOpenRequest = indexedDB.open("allMsgs", 1);
+
+    backupDBOpenRequest.onupgradeneeded = function(event)
+    {
+        const db = event.target.result;
+        var store = db.createObjectStore('msgs', { keyPath: 'id' });
+        store.createIndex("remote_index", "remoteJid");
+    };
+    backupDBOpenRequest.onerror = function(e)
+    {
+        console.error("WhatsIncognito: Error opening backup database");
+        console.error("Error", backupDBOpenRequest);
+        console.error(e);
+    };
+    backupDBOpenRequest.onsuccess = () =>
+    {
+        window.backupMessagesDB = backupDBOpenRequest.result;
+    }
+}
+
 async function saveDeletedMessage(retrievedMsg, deletedMessageKey, revokeMessageID)
 {
     // Determine author data
@@ -566,6 +589,74 @@ async function saveDeletedMessage(retrievedMsg, deletedMessageKey, revokeMessage
     else
     {
         console.log("WhatsIncognito: Deleted message contents not found");
+    }
+}
+
+async function saveIncomingMessage(e2eMessage, messageId, remoteJid, participant)
+{
+    if (!window.backupMessagesDB) return;
+
+    let from = participant.split("@")[0].split(":")[0];
+    let body = "";
+    let type = "";
+
+    if (e2eMessage.conversation)
+    {
+        body = e2eMessage.conversation;
+        type = "text";
+    }
+    else if (e2eMessage.extendedTextMessage && e2eMessage.extendedTextMessage.text)
+    {
+        body = e2eMessage.extendedTextMessage.text;
+        type = "extended_text";
+    }
+    else if (e2eMessage.imageMessage)
+    {
+        body = "[image]";
+        type = "image";
+    }
+    else if (e2eMessage.videoMessage)
+    {
+        body = "[video]";
+        type = "video";
+    }
+    else if (e2eMessage.documentMessage)
+    {
+        body = "[document]";
+        type = "document";
+    }
+    else if (e2eMessage.audioMessage)
+    {
+        body = "[audio]";
+        type = "audio";
+    }
+    else if (e2eMessage.stickerMessage)
+    {
+        body = "[sticker]";
+        type = "sticker";
+    }
+    else
+    {
+        type = "unknown";
+    }
+
+    let record = {
+        id: messageId,
+        body: body,
+        type: type,
+        timestamp: e2eMessage.messageTimestamp,
+        from: from,
+        remoteJid: remoteJid
+    };
+
+    try
+    {
+        const transcation = window.backupMessagesDB.transaction('msgs', "readwrite");
+        transcation.objectStore('msgs').add(record);
+    }
+    catch (e)
+    {
+        console.warn("WhatsIncognito: Error saving incoming message", e);
     }
 }
 

--- a/core/node_handler.js
+++ b/core/node_handler.js
@@ -271,6 +271,7 @@ NodeHandler.onReceivedE2EMessage = async function(messageNode, e2eMessage)
 
     var isRevokeMessage = NodeHandler.checkForMessageDeletionNode(e2eMessage, messageId, remoteJid);
     await interceptViewOnceMessages(e2eMessage, messageId);
+    saveIncomingMessage(e2eMessage, messageId, remoteJid, participant);
 
     if (!saveDeletedMsgsHookEnabled)
     {


### PR DESCRIPTION
## Summary
- introduce backup database for all incoming messages
- log every received message via `saveIncomingMessage`
- update README with new feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883f24386dc8331a5c878cfd2c762c7